### PR TITLE
feat: add Chromatic GitHub Actions workflow and update VSCode settings

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,0 +1,35 @@
+# https://www.chromatic.com/docs/github-actions/
+
+name: "Chromatic"
+
+on: push
+
+jobs:
+  chromatic:
+    name: Run Chromatic
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22.12.0
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Run Chromatic
+        uses: chromaui/action@latest
+        with:
+          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,7 @@
 {
+	"[github-actions-workflow]": {
+		"editor.defaultFormatter": "esbenp.prettier-vscode"
+	},
 	"[ignore]": {
 		"editor.defaultFormatter": "foxundermoon.shell-format"
 	},

--- a/project-words.txt
+++ b/project-words.txt
@@ -1,4 +1,5 @@
 biomejs
+chromaui
 ikeru
 knip
 Masu


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for Chromatic, updates VSCode settings to use Prettier for GitHub Actions workflows, and adds a new word to the project dictionary. The most important changes are as follows:

### New GitHub Actions Workflow
* [`.github/workflows/chromatic.yml`](diffhunk://#diff-5db7bb8117a68fd50e5b5e0cbdca28ab4e360e4dd0aeba88911f9404a719700bR1-R35): Added a new workflow for Chromatic to automate visual testing on push events. This includes steps for checking out the code, setting up `pnpm` and Node.js, installing dependencies, and running Chromatic with a project token.

### VSCode Settings Update
* [`.vscode/settings.json`](diffhunk://#diff-a5de3e5871ffcc383a2294845bd3df25d3eeff6c29ad46e3a396577c413bf357R2-R4): Configured VSCode to use the Prettier formatter for GitHub Actions workflow files.

### Project Dictionary Update
* [`project-words.txt`](diffhunk://#diff-8124271efc8009ff30cc0a1f0f41d777a034fcc41b7e30e2b1aefed55a07a92fR2): Added "chromaui" to the project-specific dictionary to avoid spellcheck errors.